### PR TITLE
Update renovate automerge and stability rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,20 @@
   "pre-commit": {
     "enabled": true
   },
-  "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "dependencyDashboard": true,
   "dependencyDashboardAutoclose": true,
   "separateMultipleMajor": true,
-  "stabilityDays": 3,
-  "prCreation:": "not-pending",
+  "minor": {
+    "automerge": true,
+    "stabilityDays": 3
+    "prCreation:": "not-pending",
+  },
+  "patch": {
+    "automerge": true,
+    "stabilityDays": 0
+  },
   "transitiveRemediation": true,
   "schedule": [
     "after 8pm every weekday",


### PR DESCRIPTION
# Pull Request

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] pre-commit was run locally and any changes were pushed
- [ ] test/test.sh has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Renovate waits three days of stability to PR a un update


<!-- Please describe the behavior or changes that are being added by this PR. -->

Renovate-bot should automerge patches but wait three days of stability before PR-ing minor releases

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


