### PR TITLE
tell pre-commit.ci to skip some hooks that it does not support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,5 +60,5 @@ ci:
     autoupdate_branch: ''
     autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
     autoupdate_schedule: weekly
-    skip: [hadolint,markdownlint,shfmtmt-docker,gitleaks-docker]
+    skip: [hadolint,markdownlint,shfmt-docker,gitleaks-docker]
     submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,14 @@ repos:
     rev: v8.8.6
     hooks:
       - id: gitleaks-docker
+
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: [hadolint,markdownlint,shfmt,gitleaks-docker]
+    submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,5 +60,5 @@ ci:
     autoupdate_branch: ''
     autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
     autoupdate_schedule: weekly
-    skip: [hadolint,markdownlint,shfmt,gitleaks-docker]
+    skip: [hadolint,markdownlint,shfmtmt-docker,gitleaks-docker]
     submodules: false


### PR DESCRIPTION
# Pull Request

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] pre-commit was run locally and any changes were pushed
- [ ] test/test.sh has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When pre-commit.ci runs, it fails on 

- hadolint
- markdownlint
- shfmt
- gitleaks-docker

because these are not supported on that CI platform.

Issue URL:

These hooks are skipped and the build runs green


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

[pre-commit.ci configuration](https://pre-commit.ci/#configuration).
